### PR TITLE
add interval to load balancer health check

### DIFF
--- a/templates/wordpress/1/rancher-compose.yml
+++ b/templates/wordpress/1/rancher-compose.yml
@@ -72,6 +72,7 @@ services:
     health_check:
       response_timeout: 2000
       healthy_threshold: 2
+      interval: 2000
       port: 42
       unhealthy_threshold: 3
   wordpress:


### PR DESCRIPTION
this will prevent rancher lb to generate invalid configuration that cause lb stops working (`inet 0`)